### PR TITLE
[WIP] node(s): nanocoap package removed from the firmwares

### DIFF
--- a/apps/node_bme280/Makefile
+++ b/apps/node_bme280/Makefile
@@ -19,9 +19,7 @@ USEMODULE += printf_float
 USEMODULE += gnrc_sock_udp
 USEMODULE += bme280
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_bme280/main.c
+++ b/apps/node_bme280/main.c
@@ -8,7 +8,6 @@
 
 #include "shell.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */

--- a/apps/node_bmp180/Makefile
+++ b/apps/node_bmp180/Makefile
@@ -19,9 +19,7 @@ USEMODULE += printf_float
 USEMODULE += gnrc_sock_udp
 USEMODULE += bmp180
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_bmp180/main.c
+++ b/apps/node_bmp180/main.c
@@ -8,7 +8,6 @@
 
 #include "shell.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */

--- a/apps/node_empty/Makefile
+++ b/apps/node_empty/Makefile
@@ -17,9 +17,7 @@ USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_empty/main.c
+++ b/apps/node_empty/main.c
@@ -12,7 +12,6 @@
 #include "msg.h"
 #include "xtimer.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_common.h"

--- a/apps/node_imu/Makefile
+++ b/apps/node_imu/Makefile
@@ -17,9 +17,7 @@ USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_imu/main.c
+++ b/apps/node_imu/main.c
@@ -11,7 +11,6 @@
 
 #include "board.h"
 #include "shell.h"
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */

--- a/apps/node_io1_xplained/Makefile
+++ b/apps/node_io1_xplained/Makefile
@@ -17,9 +17,7 @@ USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_io1_xplained/main.c
+++ b/apps/node_io1_xplained/main.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 
 #include "shell.h"
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */
@@ -44,13 +43,13 @@ static gcoap_listener_t _listener = {
 int main(void)
 {
     puts("RIOT IO1 XPlained Pro Node application");
-    
+
     /* gnrc which needs a msg queue */
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
-    
+
     puts("Waiting for address autoconfiguration...");
     xtimer_sleep(3);
-    
+
     /* print network addresses */
     puts("Configured network interfaces:");
     _netif_config(0, NULL);

--- a/apps/node_iotlab_a8_m3/Makefile
+++ b/apps/node_iotlab_a8_m3/Makefile
@@ -19,9 +19,7 @@ USEMODULE += printf_float
 USEMODULE += gnrc_sock_udp
 USEMODULE += lsm303dlhc
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_iotlab_a8_m3/Makefile
+++ b/apps/node_iotlab_a8_m3/Makefile
@@ -20,6 +20,9 @@ USEMODULE += gnrc_sock_udp
 USEMODULE += lsm303dlhc
 
 USEMODULE += gcoap
+# NOTE: Temporary, just for debug msgs
+USEMODULE += od
+USEMODULE += fmt
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_iotlab_a8_m3/main.c
+++ b/apps/node_iotlab_a8_m3/main.c
@@ -10,7 +10,6 @@
 #include "msg.h"
 #include "shell.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */

--- a/apps/node_leds/Makefile
+++ b/apps/node_leds/Makefile
@@ -17,9 +17,7 @@ USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 USEMODULE += xtimer
 USEMODULE += fmt

--- a/apps/node_leds/main.c
+++ b/apps/node_leds/main.c
@@ -11,7 +11,6 @@
 #include "xtimer.h"
 #include "shell.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_common.h"

--- a/apps/node_tsl2561/Makefile
+++ b/apps/node_tsl2561/Makefile
@@ -19,9 +19,7 @@ USEMODULE += printf_float
 USEMODULE += gnrc_sock_udp
 USEMODULE += tsl2561
 
-USEPKG += nanocoap
 USEMODULE += gcoap
-USEMODULE += posix
 
 # include this to get the shell
 USEMODULE += shell_commands

--- a/apps/node_tsl2561/main.c
+++ b/apps/node_tsl2561/main.c
@@ -7,7 +7,6 @@
  */
 
 #include "shell.h"
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 /* RIOT firmware libraries */

--- a/modules/coap_bme280/coap_bme280.c
+++ b/modules/coap_bme280/coap_bme280.c
@@ -12,7 +12,6 @@
 #include "bme280_params.h"
 #include "bme280.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_utils.h"

--- a/modules/coap_bme280/coap_bme280.h
+++ b/modules/coap_bme280/coap_bme280.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_bmp180/coap_bmp180.c
+++ b/modules/coap_bmp180/coap_bmp180.c
@@ -12,7 +12,6 @@
 #include "bmp180_params.h"
 #include "bmp180.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_utils.h"

--- a/modules/coap_bmp180/coap_bmp180.h
+++ b/modules/coap_bmp180/coap_bmp180.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_common/coap_common.c
+++ b/modules/coap_common/coap_common.c
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include "thread.h"
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_common.h"

--- a/modules/coap_common/coap_common.h
+++ b/modules/coap_common/coap_common.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_imu/coap_imu.c
+++ b/modules/coap_imu/coap_imu.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "saul_reg.h"

--- a/modules/coap_imu/coap_imu.h
+++ b/modules/coap_imu/coap_imu.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_io1_xplained/coap_io1_xplained.c
+++ b/modules/coap_io1_xplained/coap_io1_xplained.c
@@ -7,7 +7,6 @@
 #include "xtimer.h"
 #include "periph/i2c.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_utils.h"
@@ -36,7 +35,7 @@ ssize_t io1_xplained_temperature_handler(coap_pkt_t *pdu, uint8_t *buf, size_t l
     size_t p = 0;
     p += sprintf((char*)&response[p], "%i°C", temperature);
     response[p] = '\0';
-    
+
     size_t payload_len = sizeof(response + 1);
     memcpy(pdu->payload, response, payload_len);
 
@@ -52,7 +51,7 @@ void read_io1_xplained_temperature(int16_t *temperature)
                SENSOR_ADDR, I2C_INTERFACE);
         return;
     }
-    
+
     uint16_t data = (buffer[0] << 8) | buffer[1];
     int8_t sign = 1;
     /* Check if negative and clear sign bit. */
@@ -70,7 +69,7 @@ void read_io1_xplained_temperature(int16_t *temperature)
 void *io1_xplained_thread(void *args)
 {
     msg_init_queue(_io1_xplained_msg_queue, IO1_XPLAINED_QUEUE_SIZE);
-    
+
     for(;;) {
         int16_t temperature;
         read_io1_xplained_temperature(&temperature);

--- a/modules/coap_io1_xplained/coap_io1_xplained.h
+++ b/modules/coap_io1_xplained/coap_io1_xplained.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_iotlab_a8_m3/coap_iotlab_a8_m3.c
+++ b/modules/coap_iotlab_a8_m3/coap_iotlab_a8_m3.c
@@ -8,7 +8,6 @@
 #include "xtimer.h"
 #include "periph/i2c.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "periph/gpio.h"
@@ -39,7 +38,7 @@ ssize_t lsm303dlhc_temperature_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len
     int16_t temperature = 0;
     lsm303dlhc_read_temp(&lsm303dlhc_dev, &temperature);
     sprintf((char*)response, "%i°C", temperature);
-    
+
     size_t payload_len = sizeof(response);
     memcpy(pdu->payload, response, payload_len);
 

--- a/modules/coap_iotlab_a8_m3/coap_iotlab_a8_m3.h
+++ b/modules/coap_iotlab_a8_m3/coap_iotlab_a8_m3.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_tsl2561/coap_tsl2561.c
+++ b/modules/coap_tsl2561/coap_tsl2561.c
@@ -12,7 +12,6 @@
 #include "tsl2561_params.h"
 #include "tsl2561.h"
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 
 #include "coap_utils.h"

--- a/modules/coap_tsl2561/coap_tsl2561.h
+++ b/modules/coap_tsl2561/coap_tsl2561.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#include "nanocoap.h"
+#include "net/gcoap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/coap_utils/coap_utils.c
+++ b/modules/coap_utils/coap_utils.c
@@ -5,10 +5,64 @@
 #include "net/gcoap.h"
 #include "coap_utils.h"
 
+#include "od.h"
+#include "fmt.h"
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static sock_udp_t coap_sock;
+static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
+                          sock_udp_ep_t *remote);
+
+/*
+ * Response callback.
+ */
+static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
+                          sock_udp_ep_t *remote)
+{
+    /* TODO  Nothing? (Copy paste from gcoap example as they are data )*/
+
+#if ENABLE_DEBUG == 1 || 1
+    (void)remote;       /* not interested in the source currently */
+
+    if (req_state == GCOAP_MEMO_TIMEOUT) {
+        printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
+        return;
+    }
+    else if (req_state == GCOAP_MEMO_ERR) {
+        printf("gcoap: error in response\n");
+        return;
+    }
+
+    char *class_str = (coap_get_code_class(pdu) == COAP_CLASS_SUCCESS)
+                            ? "Success" : "Error";
+    printf("gcoap: response %s, code %1u.%02u", class_str,
+                                                coap_get_code_class(pdu),
+                                                coap_get_code_detail(pdu));
+    if (pdu->payload_len) {
+        if (pdu->content_type == COAP_FORMAT_TEXT
+                || pdu->content_type == COAP_FORMAT_LINK
+                || coap_get_code_class(pdu) == COAP_CLASS_CLIENT_FAILURE
+                || coap_get_code_class(pdu) == COAP_CLASS_SERVER_FAILURE) {
+            /* Expecting diagnostic payload in failure cases */
+            printf(", %u bytes\n%.*s\n", pdu->payload_len, pdu->payload_len,
+                                                          (char *)pdu->payload);
+        }
+        else {
+            printf(", %u bytes\n", pdu->payload_len);
+            od_hex_dump(pdu->payload, pdu->payload_len, OD_WIDTH_DEFAULT);
+        }
+    }
+    else {
+        printf(", empty payload\n");
+    }
+#else
+    (void) req_state;
+    (void) pdu;
+    (void) remote;
+#endif
+
+}
 
 void send_coap_post(uint8_t* uri_path, uint8_t *data)
 {
@@ -36,5 +90,6 @@ void send_coap_post(uint8_t* uri_path, uint8_t *data)
 
     DEBUG("[INFO] Sending '%s' to '%s:%i%s'\n", data, BROKER_ADDR, BROKER_PORT, uri_path);
 
-    sock_udp_send(&coap_sock, buf, len, &remote);
+    gcoap_req_send2(&buf[0], len, &remote, _resp_handler);
+
 }

--- a/modules/coap_utils/coap_utils.c
+++ b/modules/coap_utils/coap_utils.c
@@ -1,7 +1,6 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#include "nanocoap.h"
 #include "net/gcoap.h"
 #include "coap_utils.h"
 

--- a/modules/coap_utils/coap_utils.c
+++ b/modules/coap_utils/coap_utils.c
@@ -22,7 +22,7 @@ static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
 {
     /* TODO  Nothing? (Copy paste from gcoap example as they are data )*/
 
-#if ENABLE_DEBUG == 1 || 1
+#if ENABLE_DEBUG == 1
     (void)remote;       /* not interested in the source currently */
 
     if (req_state == GCOAP_MEMO_TIMEOUT) {
@@ -90,6 +90,6 @@ void send_coap_post(uint8_t* uri_path, uint8_t *data)
 
     DEBUG("[INFO] Sending '%s' to '%s:%i%s'\n", data, BROKER_ADDR, BROKER_PORT, uri_path);
 
-    gcoap_req_send2(&buf[0], len, &remote, _resp_handler);
+    gcoap_req_send2(&buf[0], len, &remote, (gcoap_resp_handler_t ) _resp_handler);
 
 }


### PR DESCRIPTION
This upgrades  the application's Makefiles to the current support for the gcoap module:

Reason behind this commit:
1. gcoap invokes the nanocoap package by itself.
2. the module posix is not anymore required by gcoap.

WIP Status
---

Tested with success for: 

- [ ] node_bme280
- [ ] node_bmp180
- [ ] node_empty
- [ ] node_imu
- [ ] node_io1_xplained
- [X] node_iotlab_a8_m3
- [ ] node_leds
- [ ] node_tsl2561

### node_iotlab_a8_m3

It's compiled without error. The node is able to send the measure to the server, and an ACK is sent by the server to the sensor.

_Note_: I'm testing with a local server and a sensor from the FIT IoT-Testbed. 

### node_bme280

It's not compiling but the error seems to come from another source: 

```
~/Projects/riot-firmwares/modules/coap_bme280/coap_bme280.c:12:27: fatal error: bme280_params.h: No such file or directory
```

### node_mqtt_bme280

It's using MQTT. Therefore, not included in the list. Also, it's having the same issue than the `node_bme280`

