### PR TITLE
Refactor Appliactions

### DIFF
--- a/apps/Makefile.dep
+++ b/apps/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter coap_% mqtt_%,$(USEMODULE)))
+  # Include packages that pull up and auto-init the link layer.
+  # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+  USEMODULE += gnrc_netdev_default
+  USEMODULE += auto_init_gnrc_netif
+  # Specify the mandatory networking modules for IPv6 and UDP
+  USEMODULE += gnrc_ipv6_default
+  # Additional networking modules that can be dropped if not needed
+  USEMODULE += gnrc_icmpv6_echo
+  USEMODULE += gnrc_sock_udp
+endif
+
+ifneq (,$(filter coap_%,$(USEMODULE)))
+  USEMODULE += gcoap
+endif
+
+ifneq (,$(filter mqtt_%,$(USEMODULE)))
+  USEMODULE += emcute
+endif

--- a/apps/Makefile.dep
+++ b/apps/Makefile.dep
@@ -1,3 +1,5 @@
+PSEUDOMODULES += shell_common
+
 ifneq (,$(filter coap_% mqtt_%,$(USEMODULE)))
   # Include packages that pull up and auto-init the link layer.
   # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
@@ -16,4 +18,10 @@ endif
 
 ifneq (,$(filter mqtt_%,$(USEMODULE)))
   USEMODULE += emcute
+endif
+
+ifneq (,$(filter shell_common,$(USEMODULE)))
+  USEMODULE += shell_commands
+  USEMODULE += shell
+  USEMODULE += ps
 endif

--- a/apps/Makefile.include
+++ b/apps/Makefile.include
@@ -1,0 +1,75 @@
+ifneq (,$(filter coap_bmp180, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_bmp180
+INCLUDES += -I$(CURDIR)/../../modules/coap_bmp180
+endif
+
+ifneq (,$(filter coap_bmx280, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_bmx280
+INCLUDES += -I$(CURDIR)/../../modules/coap_bmx280
+endif
+
+ifneq (,$(filter coap_ccs811, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_ccs811
+INCLUDES += -I$(CURDIR)/../../modules/coap_ccs811
+endif
+
+ifneq (,$(filter coap_common, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_common
+INCLUDES += -I$(CURDIR)/../../modules/coap_common
+endif
+
+ifneq (,$(filter coap_imu, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_imu
+INCLUDES += -I$(CURDIR)/../../modules/coap_imu
+endif
+
+ifneq (,$(filter coap_iotlab_a8_m3, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_iotlab_a8_m3
+INCLUDES += -I$(CURDIR)/../../modules/coap_iotlab_a8_m3
+endif
+
+ifneq (,$(filter coap_io1_xplained, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_io1_xplained
+INCLUDES += -I$(CURDIR)/../../modules/coap_io1_xplained
+endif
+
+ifneq (,$(filter coap_led, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_led
+INCLUDES += -I$(CURDIR)/../../modules/coap_led
+endif
+
+ifneq (,$(filter coap_position, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_position
+INCLUDES += -I$(CURDIR)/../../modules/coap_position
+endif
+
+ifneq (,$(filter coap_suit, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_suit
+INCLUDES += -I$(CURDIR)/../../modules/coap_suit
+include $(CURDIR)/../../modules/coap_suit/Makefile.include
+endif
+
+ifneq (,$(filter coap_tsl2561, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_tsl2561
+INCLUDES += -I$(CURDIR)/../../modules/coap_tsl2561
+endif
+
+ifneq (,$(filter coap_utils, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/coap_utils
+INCLUDES += -I$(CURDIR)/../../modules/coap_utils
+endif
+
+ifneq (,$(filter mqtt_common, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/mqtt_common
+INCLUDES += -I$(CURDIR)/../../modules/mqtt_common
+endif
+
+ifneq (,$(filter mqtt_bmx280, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/mqtt_bmx280
+INCLUDES += -I$(CURDIR)/../../modules/mqtt_bmx280
+endif
+
+ifneq (,$(filter mqtt_utils, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/mqtt_utils
+INCLUDES += -I$(CURDIR)/../../modules/mqtt_utils
+endif

--- a/apps/node_bmp180/Makefile
+++ b/apps/node_bmp180/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_bmp180
 
 # If no BOARD is found in the environment, use this default:
@@ -7,15 +7,12 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
 USEMODULE += printf_float
 USEMODULE += bmp180
+USEMODULE += shell_common
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position

--- a/apps/node_bmp180/Makefile
+++ b/apps/node_bmp180/Makefile
@@ -7,26 +7,14 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
+# Application specific modules
 USEMODULE += printf_float
-USEMODULE += gnrc_sock_udp
 USEMODULE += bmp180
-
-USEMODULE += gcoap
 
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -42,17 +30,8 @@ APPLICATION_NAME ?= "Weather\ Sensor"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
-
-DIRS += $(CURDIR)/../../modules/coap_bmp180
-INCLUDES += -I$(CURDIR)/../../modules/coap_bmp180
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_bmx280/Makefile
+++ b/apps/node_bmx280/Makefile
@@ -9,26 +9,14 @@ DRIVER ?= bme280
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
+# Application specific modules
 USEMODULE += printf_float
-USEMODULE += gnrc_sock_udp
 USEMODULE += $(DRIVER)
-
-USEMODULE += gcoap
 
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -44,17 +32,8 @@ APPLICATION_NAME ?= "Weather\ Sensor"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
-
-DIRS += $(CURDIR)/../../modules/coap_bmx280
-INCLUDES += -I$(CURDIR)/../../modules/coap_bmx280
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_bmx280/Makefile
+++ b/apps/node_bmx280/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_bmx280
 
 # If no BOARD is found in the environment, use this default:
@@ -9,15 +9,12 @@ DRIVER ?= bme280
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
 USEMODULE += printf_float
 USEMODULE += $(DRIVER)
+USEMODULE += shell_common
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position

--- a/apps/node_ccs811/Makefile
+++ b/apps/node_ccs811/Makefile
@@ -7,25 +7,13 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_sock_udp
+# Application specific modules
 USEMODULE += ccs811
-
-USEMODULE += gcoap
 
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -41,17 +29,8 @@ APPLICATION_NAME ?= "Gas\ Sensor"
 BROKER_ADDR ?= fd00:abad:1e:102::1
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
-
-DIRS += $(CURDIR)/../../modules/coap_ccs811
-INCLUDES += -I$(CURDIR)/../../modules/coap_ccs811
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_ccs811/Makefile
+++ b/apps/node_ccs811/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_ccs811
 
 # If no BOARD is found in the environment, use this default:
@@ -7,14 +7,11 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
 USEMODULE += ccs811
+USEMODULE += shell_common
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position

--- a/apps/node_empty/Makefile
+++ b/apps/node_empty/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_empty
 
 # If no BOARD is found in the environment, use this default:
@@ -8,10 +8,9 @@ BOARD ?= samr21-xpro
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
 # include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
+USEMODULE += shell_common
 
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position

--- a/apps/node_empty/Makefile
+++ b/apps/node_empty/Makefile
@@ -7,24 +7,10 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_sock_udp
-
-USEMODULE += gcoap
-
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -41,14 +27,8 @@ BROKER_PORT ?= 5683
 NODE_LAT ?= 48.714784
 NODE_LNG ?= 2.205502
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_imu/Makefile
+++ b/apps/node_imu/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_imu
 
 # If no BOARD is found in the environment, use this default:
@@ -8,11 +8,10 @@ BOARD = iotlab-m3
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
 # include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+USEMODULE += shell_common
 USEMODULE += xtimer
+
+# Required Features
 FEATURES_REQUIRED += periph_gpio
 
 # Add the sensors
@@ -20,6 +19,7 @@ USEMODULE += saul_reg
 USEMODULE += saul_default
 USEMODULE += auto_init_saul
 
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_imu

--- a/apps/node_imu/Makefile
+++ b/apps/node_imu/Makefile
@@ -7,27 +7,12 @@ BOARD = iotlab-m3
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_sock_udp
-
-USEMODULE += gcoap
-
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += xtimer
-
 FEATURES_REQUIRED += periph_gpio
 
 # Add the sensors
@@ -39,6 +24,11 @@ USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_imu
 
+# Needed because of unuesed variuable in stm32_common/perip/i2c_2.c
+# Fixed in Master but waiting for 2019.04-branch release that has the
+# bug fix
+DEVELHELP ?= 1
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
@@ -48,14 +38,8 @@ APPLICATION_NAME ?= "IMU\ Unit"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_imu
-INCLUDES += -I$(CURDIR)/../../modules/coap_imu
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_io1_xplained/Makefile
+++ b/apps/node_io1_xplained/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_io1_xplained
 
 # If no BOARD is found in the environment, use this default:
@@ -7,15 +7,14 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Riot Application modules
+USEMODULE += shell_common
 USEMODULE += xtimer
 
+# Required Features
 FEATURES_REQUIRED += periph_i2c
 
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_io1_xplained

--- a/apps/node_io1_xplained/Makefile
+++ b/apps/node_io1_xplained/Makefile
@@ -7,24 +7,10 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_sock_udp
-
-USEMODULE += gcoap
-
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += xtimer
 
@@ -43,14 +29,8 @@ APPLICATION_NAME ?= "Node\ IO1\ Xplained"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_io1_xplained
-INCLUDES += -I$(CURDIR)/../../modules/coap_io1_xplained
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_iotlab_a8_m3/Makefile
+++ b/apps/node_iotlab_a8_m3/Makefile
@@ -7,15 +7,12 @@ BOARD = iotlab-a8-m3
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
 USEMODULE += printf_float
 USEMODULE += lsm303dlhc
+USEMODULE += shell_common
 
-# include this to get the shell with common functionalities
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_led

--- a/apps/node_iotlab_a8_m3/Makefile
+++ b/apps/node_iotlab_a8_m3/Makefile
@@ -7,26 +7,14 @@ BOARD = iotlab-a8-m3
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
+# Application specific modules
 USEMODULE += printf_float
-USEMODULE += gnrc_sock_udp
 USEMODULE += lsm303dlhc
 
-USEMODULE += gcoap
-
-# include this to get the shell
+# include this to get the shell with common functionalities
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -37,6 +25,11 @@ USEMODULE += coap_iotlab_a8_m3
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+# Needed because of unuesed variuable in stm32_common/perip/i2c_2.c
+# Fixed in Master but waiting for 2019.04-branch release that has the
+# bug fix
+DEVELHELP ?= 1
+
 # Application specific definitions and includes
 APPLICATION_NAME ?= "IoT-Lab\ A8\ Node"
 NODE_LAT ?= 48.714784
@@ -45,20 +38,8 @@ NODE_LNG ?= 2.205502
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
-
-DIRS += $(CURDIR)/../../modules/coap_led
-INCLUDES += -I$(CURDIR)/../../modules/coap_led
-
-DIRS += $(CURDIR)/../../modules/coap_iotlab_a8_m3
-INCLUDES += -I$(CURDIR)/../../modules/coap_iotlab_a8_m3
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_leds/Makefile
+++ b/apps/node_leds/Makefile
@@ -7,18 +7,7 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_sock_udp
-
-USEMODULE += gcoap
-
+# Application specific modules
 USEMODULE += xtimer
 USEMODULE += fmt
 
@@ -26,8 +15,6 @@ USEMODULE += fmt
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 FEATURES_REQUIRED += periph_gpio
 
@@ -44,14 +31,8 @@ APPLICATION_NAME ?= "Node\ LED"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_led
-INCLUDES += -I$(CURDIR)/../../modules/coap_led
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_leds/Makefile
+++ b/apps/node_leds/Makefile
@@ -7,17 +7,15 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
+USEMODULE += shell_common
 USEMODULE += xtimer
 USEMODULE += fmt
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Required Features
 FEATURES_REQUIRED += periph_gpio
 
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_led

--- a/apps/node_mqtt_bmx280/Makefile
+++ b/apps/node_mqtt_bmx280/Makefile
@@ -9,23 +9,10 @@ DRIVER ?= bme280
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_sock_udp
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_ipv6_default
-# Include MQTT-SN
-USEMODULE += emcute
-
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += mqtt_utils
 USEMODULE += mqtt_common
@@ -42,14 +29,8 @@ APPLICATION_NAME ?= "Node\ BME280\ MQTT-SN"
 GATEWAY_ADDR ?= fd00:abad:1e:102::1
 GATEWAY_PORT ?= 1885
 
-DIRS += $(CURDIR)/../../modules/mqtt_common
-INCLUDES += -I$(CURDIR)/../../modules/mqtt_common
-
-DIRS += $(CURDIR)/../../modules/mqtt_bmx280
-INCLUDES += -I$(CURDIR)/../../modules/mqtt_bmx280
-
-DIRS += $(CURDIR)/../../modules/mqtt_utils
-INCLUDES += -I$(CURDIR)/../../modules/mqtt_utils
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 

--- a/apps/node_mqtt_bmx280/Makefile
+++ b/apps/node_mqtt_bmx280/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_mqtt_bmx280
 
 # If no BOARD is found in the environment, use this default:
@@ -9,11 +9,10 @@ DRIVER ?= bme280
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
+# Riot Application modules
+USEMODULE += shell_common
 
+# Include pyaiot modules
 USEMODULE += mqtt_utils
 USEMODULE += mqtt_common
 USEMODULE += mqtt_bmx280

--- a/apps/node_tsl2561/Makefile
+++ b/apps/node_tsl2561/Makefile
@@ -1,4 +1,4 @@
-# name of your application
+# Name of your application
 APPLICATION = node_tsl2561
 
 # If no BOARD is found in the environment, use this default:
@@ -7,15 +7,12 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Application specific modules
+# Riot Application modules
 USEMODULE += printf_float
 USEMODULE += tsl2561
+USEMODULE += shell_common
 
-# include this to get the shell
-USEMODULE += shell_commands
-USEMODULE += shell
-USEMODULE += ps
-
+# Include pyaiot modules
 USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position

--- a/apps/node_tsl2561/Makefile
+++ b/apps/node_tsl2561/Makefile
@@ -7,26 +7,14 @@ BOARD = samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
+# Application specific modules
 USEMODULE += printf_float
-USEMODULE += gnrc_sock_udp
 USEMODULE += tsl2561
-
-USEMODULE += gcoap
 
 # include this to get the shell
 USEMODULE += shell_commands
 USEMODULE += shell
 USEMODULE += ps
-USEMODULE += netstats_l2
-USEMODULE += netstats_ipv6
 
 USEMODULE += coap_common
 USEMODULE += coap_utils
@@ -42,17 +30,8 @@ APPLICATION_NAME ?= "Light\ Sensor"
 BROKER_ADDR ?= 2001:660:3207:102::4
 BROKER_PORT ?= 5683
 
-DIRS += $(CURDIR)/../../modules/coap_common
-INCLUDES += -I$(CURDIR)/../../modules/coap_common
-
-DIRS += $(CURDIR)/../../modules/coap_utils
-INCLUDES += -I$(CURDIR)/../../modules/coap_utils
-
-DIRS += $(CURDIR)/../../modules/coap_position
-INCLUDES += -I$(CURDIR)/../../modules/coap_position
-
-DIRS += $(CURDIR)/../../modules/coap_tsl2561
-INCLUDES += -I$(CURDIR)/../../modules/coap_tsl2561
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
This pr refactors the applications:

- moves all DIRS and INCLUDES to a base Makefile.include
- networking modules are included according to dependencies specified in Makefile.deps
- pseudomodule that encapsulate used shell modules
- minor comments unification