### PR TITLE
pr: add schedreg module

### DIFF
--- a/apps/Makefile.include
+++ b/apps/Makefile.include
@@ -73,3 +73,9 @@ ifneq (,$(filter mqtt_utils, $(USEMODULE)))
 DIRS += $(CURDIR)/../../modules/mqtt_utils
 INCLUDES += -I$(CURDIR)/../../modules/mqtt_utils
 endif
+
+ifneq (,$(filter schedreg, $(USEMODULE)))
+DIRS += $(CURDIR)/../../modules/schedreg
+INCLUDES += -I$(CURDIR)/../../modules/schedreg
+endif
+

--- a/apps/node_bmx280/Makefile
+++ b/apps/node_bmx280/Makefile
@@ -19,6 +19,7 @@ USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position
 USEMODULE += coap_bmx280
+USEMODULE += schedreg
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/apps/node_bmx280/main.c
+++ b/apps/node_bmx280/main.c
@@ -15,6 +15,10 @@
 #include "coap_common.h"
 #include "coap_position.h"
 #include "coap_bmx280.h"
+#include "schedreg.h"
+
+#define BMX280_SEND_INTERVAL        (5*US_PER_SEC)
+#define BEACON_SEND_INTERVAL        (30*US_PER_SEC)
 
 static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
@@ -62,8 +66,25 @@ int main(void)
 
     /* start coap server loop */
     gcoap_register_listener(&_listener);
+
+    /* init schedreg thread */
+    kernel_pid_t sched_pid = init_schedreg_thread();
+
+    /* start beacon and register */
     init_beacon_sender();
+    xtimer_t beacon_xtimer;
+    msg_t beacon_msg;
+    schedreg_t beacon_reg = SCHEDREG_INIT(beacon_handler, NULL, &beacon_msg,
+                                          &beacon_xtimer, BEACON_SEND_INTERVAL);
+    schedreg_register(&beacon_reg, sched_pid);
+
+    /* start bmx280 and register */
     init_bmx280_sender(true, true, true);
+    xtimer_t bmx280_xtimer;
+    msg_t bmx280_msg;
+    schedreg_t bmx280_reg = SCHEDREG_INIT(bmx280_handler, NULL, &bmx280_msg,
+                                          &bmx280_xtimer, BMX280_SEND_INTERVAL);
+    schedreg_register(&bmx280_reg, sched_pid);
 
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/apps/node_ccs811/Makefile
+++ b/apps/node_ccs811/Makefile
@@ -16,6 +16,7 @@ USEMODULE += coap_common
 USEMODULE += coap_utils
 USEMODULE += coap_position
 USEMODULE += coap_ccs811
+USEMODULE += schedreg
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/apps/node_ccs811/main.c
+++ b/apps/node_ccs811/main.c
@@ -15,6 +15,10 @@
 #include "coap_common.h"
 #include "coap_position.h"
 #include "coap_ccs811.h"
+#include "schedreg.h"
+
+#define CCS811_SEND_INTERVAL        (5*US_PER_SEC)
+#define BEACON_SEND_INTERVAL        (30*US_PER_SEC)
 
 static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
@@ -59,8 +63,25 @@ int main(void)
 
     /* start coap server loop */
     gcoap_register_listener(&_listener);
+
+    /* init schedreg thread */
+    kernel_pid_t sched_pid = init_schedreg_thread();
+
+    /* start beacon and register */
     init_beacon_sender();
+    xtimer_t beacon_xtimer;
+    msg_t beacon_msg;
+    schedreg_t beacon_reg = SCHEDREG_INIT(beacon_handler, NULL, &beacon_msg,
+                                          &beacon_xtimer, BEACON_SEND_INTERVAL);
+    schedreg_register(&beacon_reg, sched_pid);
+
+    /* start ccs811 and register */
     init_ccs811_sender(true, true);
+    xtimer_t ccs811_xtimer;
+    msg_t ccs811_msg;
+    schedreg_t ccs811_reg = SCHEDREG_INIT(ccs811_handler, NULL, &ccs811_msg,
+                                          &ccs811_xtimer, CCS811_SEND_INTERVAL);
+    schedreg_register(&ccs811_reg, sched_pid);
 
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/apps/node_combo/Makefile
+++ b/apps/node_combo/Makefile
@@ -1,0 +1,58 @@
+# Name of your application
+APPLICATION = node_combo
+
+# If no BOARD is found in the environment, use this default:
+BOARD = samr21-xpro
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../RIOT
+
+DRIVER ?= bme280
+
+# Riot Application modules
+USEMODULE += ccs811
+USEMODULE += shell_common
+USEMODULE += $(DRIVER)
+
+# Include pyaiot modules
+USEMODULE += coap_common
+USEMODULE += coap_utils
+USEMODULE += coap_position
+USEMODULE += coap_ccs811
+USEMODULE += coap_bmx280
+USEMODULE += schedreg
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Application specific definitions and includes
+APPLICATION_NAME ?= "Air\ Quality\ Monitor"
+# CoAP broker server information
+BROKER_ADDR ?= fd00:abad:1e:102::1
+BROKER_PORT ?= 5683
+
+# Change default address for sparkfun CCS811 BMX280 combo board
+CFLAGS += -DCCS811_PARAM_I2C_ADDR=CCS811_I2C_ADDRESS_2
+
+include $(CURDIR)/../Makefile.dep
+include $(CURDIR)/../Makefile.include
+
+include $(RIOTBASE)/Makefile.include
+
+CFLAGS += -DBROKER_ADDR=\"$(BROKER_ADDR)\"
+CFLAGS += -DBROKER_PORT=$(BROKER_PORT)
+CFLAGS += -DAPPLICATION_NAME="\"$(APPLICATION_NAME)\""
+
+# Set a custom channel if needed
+ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    FLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                          # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/apps/node_combo/main.c
+++ b/apps/node_combo/main.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "shell.h"
+
+#include "net/nanocoap.h"
+#include "net/gcoap.h"
+
+/* RIOT firmware libraries */
+#include "coap_common.h"
+#include "coap_position.h"
+#include "coap_ccs811.h"
+#include "coap_bmx280.h"
+#include "schedreg.h"
+
+#define BMX280_SEND_INTERVAL        (5*US_PER_SEC)
+#define CCS811_SEND_INTERVAL        (5*US_PER_SEC)
+#define BEACON_SEND_INTERVAL        (30*US_PER_SEC)
+
+static const shell_command_t shell_commands[] = {
+    { NULL, NULL, NULL }
+};
+
+#define MAIN_QUEUE_SIZE       (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+/* import "ifconfig" shell command, used for printing addresses */
+extern int _gnrc_netif_config(int argc, char **argv);
+
+/* CoAP resources (alphabetical order) */
+static const coap_resource_t _resources[] = {
+    { "/board", COAP_GET, board_handler, NULL },
+    { "/eco2", COAP_GET, ccs811_eco2_handler, NULL },
+#ifdef MODULE_BME280
+    { "/humidity", COAP_GET, bmx280_humidity_handler, NULL },
+#endif
+    { "/mcu", COAP_GET, mcu_handler, NULL },
+    { "/name", COAP_GET, name_handler, NULL },
+    { "/os", COAP_GET, os_handler, NULL },
+    { "/position", COAP_GET, position_handler, NULL },
+    { "/pressure", COAP_GET, bmx280_pressure_handler, NULL },
+    { "/temperature", COAP_GET, bmx280_temperature_handler, NULL },
+    { "/tvoc", COAP_GET, ccs811_tvoc_handler, NULL },
+};
+
+static gcoap_listener_t _listener = {
+    (coap_resource_t *)&_resources[0],
+    sizeof(_resources) / sizeof(_resources[0]),
+    NULL
+};
+
+int main(void)
+{
+    puts("RIOT CCS811 BMX280 Combo Node application");
+
+    /* gnrc which needs a msg queue */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+
+    puts("Waiting for address autoconfiguration...");
+    xtimer_sleep(3);
+
+    /* print network addresses */
+    puts("Configured network interfaces:");
+    _gnrc_netif_config(0, NULL);
+
+    /* start coap server loop */
+    gcoap_register_listener(&_listener);
+
+    /* init schedreg thread */
+    kernel_pid_t sched_pid = init_schedreg_thread();
+
+    /* start beacon and register */
+    init_beacon_sender();
+    xtimer_t beacon_xtimer;
+    msg_t beacon_msg;
+    schedreg_t beacon_reg = SCHEDREG_INIT(beacon_handler, NULL, &beacon_msg,
+                                          &beacon_xtimer, BEACON_SEND_INTERVAL);
+    schedreg_register(&beacon_reg, sched_pid);
+
+    /* start ccs811 and register */
+    init_ccs811_sender(true, true);
+    xtimer_t ccs811_xtimer;
+    msg_t ccs811_msg;
+    schedreg_t ccs811_reg = SCHEDREG_INIT(ccs811_handler, NULL, &ccs811_msg,
+                                          &ccs811_xtimer, CCS811_SEND_INTERVAL);
+    schedreg_register(&ccs811_reg, sched_pid);
+
+    /* start bmx280 and register */
+    init_bmx280_sender(true, true, true);
+    xtimer_t bmx280_xtimer;
+    msg_t bmx280_msg;
+    schedreg_t bmx280_reg = SCHEDREG_INIT(bmx280_handler, NULL, &bmx280_msg,
+                                          &bmx280_xtimer, BMX280_SEND_INTERVAL);
+    schedreg_register(&bmx280_reg, sched_pid);
+
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/modules/coap_bmx280/coap_bme280.c
+++ b/modules/coap_bmx280/coap_bme280.c
@@ -5,8 +5,6 @@
 #include <string.h>
 
 #include "msg.h"
-#include "thread.h"
-#include "xtimer.h"
 #include "periph/i2c.h"
 
 #include "bmx280_params.h"
@@ -19,13 +17,6 @@
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-
-#define SEND_INTERVAL              (5000000UL)    /* set temperature updates interval to 5 seconds */
-
-#define BMX280_QUEUE_SIZE    (8)
-
-static msg_t _bmx280_msg_queue[BMX280_QUEUE_SIZE];
-static char bmx280_stack[THREAD_STACKSIZE_DEFAULT];
 
 static bmx280_t bmx280_dev;
 static uint8_t response[64] = { 0 };
@@ -91,56 +82,48 @@ ssize_t bmx280_humidity_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void 
 }
 #endif
 
-void *bmx280_thread(void *args)
+void bmx280_handler(void *args)
 {
-    (void)args;
-    msg_init_queue(_bmx280_msg_queue, BMX280_QUEUE_SIZE);
+    (void) args;
 
-    for(;;) {
-        if (use_temperature) {
-            ssize_t p = 0;
-            int16_t temp = bmx280_read_temperature(&bmx280_dev);
-            bool negative = (temp < 0);
-            if (negative) {
-                temp = -temp;
-            }
-            p += sprintf((char*)&response[p], "temperature:");
-            p += sprintf((char*)&response[p], "%s%d.%d°C",
-                         negative ? "-" : "",
-                         temp / 100, (temp % 100) /10);
-            response[p] = '\0';
-            send_coap_post((uint8_t*)"/server", response);
+    if (use_temperature) {
+        ssize_t p = 0;
+        int16_t temp = bmx280_read_temperature(&bmx280_dev);
+        bool negative = (temp < 0);
+        if (negative) {
+            temp = -temp;
         }
-
-        if (use_pressure) {
-            ssize_t p = 0;
-            uint32_t pres = bmx280_read_pressure(&bmx280_dev);
-            p += sprintf((char*)&response[p], "pressure:");
-            p += sprintf((char*)&response[p], "%lu.%dhPa",
-                         (unsigned long)pres / 100,
-                         (int)pres % 100);
-            response[p] = '\0';
-            send_coap_post((uint8_t*)"/server", response);
-        }
-
-#ifdef MODULE_BME280
-        if (use_humidity) {
-            ssize_t p = 0;
-            uint16_t hum = bme280_read_humidity(&bmx280_dev);
-            p += sprintf((char*)&response[p], "humidity:");
-            p += sprintf((char*)&response[p], "%u.%02u%%",
-                         (unsigned int)(hum / 100),
-                         (unsigned int)(hum % 100));
-            response[p] = '\0';
-            send_coap_post((uint8_t*)"/server", response);
-        }
-#endif
-
-        /* wait 5 seconds */
-        xtimer_usleep(SEND_INTERVAL);
+        p += sprintf((char*)&response[p], "temperature:");
+        p += sprintf((char*)&response[p], "%s%d.%d°C",
+                        negative ? "-" : "",
+                        temp / 100, (temp % 100) /10);
+        response[p] = '\0';
+        send_coap_post((uint8_t*)"/server", response);
     }
 
-    return NULL;
+    if (use_pressure) {
+        ssize_t p = 0;
+        uint32_t pres = bmx280_read_pressure(&bmx280_dev);
+        p += sprintf((char*)&response[p], "pressure:");
+        p += sprintf((char*)&response[p], "%lu.%dhPa",
+                        (unsigned long)pres / 100,
+                        (int)pres % 100);
+        response[p] = '\0';
+        send_coap_post((uint8_t*)"/server", response);
+    }
+
+#ifdef MODULE_BME280
+    if (use_humidity) {
+        ssize_t p = 0;
+        uint16_t hum = bme280_read_humidity(&bmx280_dev);
+        p += sprintf((char*)&response[p], "humidity:");
+        p += sprintf((char*)&response[p], "%u.%02u%%",
+                        (unsigned int)(hum / 100),
+                        (unsigned int)(hum % 100));
+        response[p] = '\0';
+        send_coap_post((uint8_t*)"/server", response);
+    }
+#endif
 }
 
 void init_bmx280_sender(bool temperature, bool pressure, bool humidity)
@@ -162,18 +145,5 @@ void init_bmx280_sender(bool temperature, bool pressure, bool humidity)
     }
     else {
         printf("Initialization successful\n\n");
-    }
-
-    /* create the sensors thread that will send periodic updates to
-       the server */
-    int bmx280_pid = thread_create(bmx280_stack, sizeof(bmx280_stack),
-                                   THREAD_PRIORITY_MAIN - 1,
-                                   THREAD_CREATE_STACKTEST, bmx280_thread,
-                                   NULL, "bmx280 thread");
-    if (bmx280_pid == -EINVAL || bmx280_pid == -EOVERFLOW) {
-        puts("Error: failed to create bmx280 thread, exiting\n");
-    }
-    else {
-        puts("Successfuly created bmx280 thread !\n");
     }
 }

--- a/modules/coap_bmx280/coap_bmx280.h
+++ b/modules/coap_bmx280/coap_bmx280.h
@@ -17,6 +17,7 @@ ssize_t bmx280_humidity_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void 
 #endif
 
 void init_bmx280_sender(bool temperature, bool pressure, bool humidity);
+void bmx280_handler(void *args);
 
 #ifdef __cplusplus
 }

--- a/modules/coap_ccs811/coap_ccs811.c
+++ b/modules/coap_ccs811/coap_ccs811.c
@@ -5,8 +5,6 @@
 #include <string.h>
 
 #include "msg.h"
-#include "thread.h"
-#include "xtimer.h"
 #include "periph/i2c.h"
 
 #include "ccs811_params.h"
@@ -20,14 +18,9 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define SEND_INTERVAL        (5000000UL)    /* set updates interval to 5 seconds */
-
 #define CCS811_QUEUE_SIZE    (8)
 
 #define I2C_DEVICE           (0)
-
-static msg_t _ccs811_msg_queue[CCS811_QUEUE_SIZE];
-static char ccs811_stack[THREAD_STACKSIZE_DEFAULT];
 
 static ccs811_t ccs811_dev;
 static uint8_t response[64] = { 0 };
@@ -63,37 +56,29 @@ ssize_t ccs811_tvoc_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx
     return gcoap_finish(pdu, payload_len, COAP_FORMAT_TEXT);
 }
 
-void *ccs811_thread(void *args)
+void ccs811_handler(void *args)
 {
     (void) args;
-    msg_init_queue(_ccs811_msg_queue, CCS811_QUEUE_SIZE);
 
-    for(;;) {
-        if (use_eco2) {
-            ssize_t p = 0;
-            uint16_t eco2;
-            ccs811_read_iaq(&ccs811_dev, NULL, &eco2, NULL, NULL);
-            p += sprintf((char*)&response[p], "eco2:");
-            p += sprintf((char*)&response[p], "%ippm", eco2);
-            response[p] = '\0';
-            send_coap_post((uint8_t*)"/server", response);
-        }
-
-        if (use_tvoc) {
-            ssize_t p = 0;
-            uint16_t tvoc;
-            ccs811_read_iaq(&ccs811_dev, &tvoc, NULL, NULL, NULL);
-            p += sprintf((char*)&response[p], "tvoc:");
-            p += sprintf((char*)&response[p], "%ippb", tvoc);
-            response[p] = '\0';
-            send_coap_post((uint8_t*)"/server", response);
-        }
-
-        /* wait 5 seconds */
-        xtimer_usleep(SEND_INTERVAL);
+    if (use_eco2) {
+        ssize_t p = 0;
+        uint16_t eco2;
+        ccs811_read_iaq(&ccs811_dev, NULL, &eco2, NULL, NULL);
+        p += sprintf((char*)&response[p], "eco2:");
+        p += sprintf((char*)&response[p], "%ippm", eco2);
+        response[p] = '\0';
+        send_coap_post((uint8_t*)"/server", response);
     }
 
-    return NULL;
+    if (use_tvoc) {
+        ssize_t p = 0;
+        uint16_t tvoc;
+        ccs811_read_iaq(&ccs811_dev, &tvoc, NULL, NULL, NULL);
+        p += sprintf((char*)&response[p], "tvoc:");
+        p += sprintf((char*)&response[p], "%ippb", tvoc);
+        response[p] = '\0';
+        send_coap_post((uint8_t*)"/server", response);
+    }
 }
 
 void init_ccs811_sender(bool eco2, bool tvoc)
@@ -109,18 +94,5 @@ void init_ccs811_sender(bool eco2, bool tvoc)
     }
     else {
         printf("Initialization successful\n\n");
-    }
-
-    /* create the sensors thread that will send periodic updates to
-       the server */
-    int ccs811_pid = thread_create(ccs811_stack, sizeof(ccs811_stack),
-                                   THREAD_PRIORITY_MAIN - 1,
-                                   THREAD_CREATE_STACKTEST, ccs811_thread,
-                                   NULL, "ccs811 thread");
-    if (ccs811_pid == -EINVAL || ccs811_pid == -EOVERFLOW) {
-        puts("Error: failed to create ccs811 thread, exiting\n");
-    }
-    else {
-        puts("Successfuly created ccs811 thread !\n");
     }
 }

--- a/modules/coap_ccs811/coap_ccs811.h
+++ b/modules/coap_ccs811/coap_ccs811.h
@@ -14,6 +14,7 @@ ssize_t ccs811_eco2_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx
 ssize_t ccs811_tvoc_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
 void init_ccs811_sender(bool eco2, bool tvoc);
+void ccs811_handler(void *args);
 
 #ifdef __cplusplus
 }

--- a/modules/coap_common/coap_common.h
+++ b/modules/coap_common/coap_common.h
@@ -15,6 +15,7 @@ ssize_t mcu_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 ssize_t os_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
 void init_beacon_sender(void);
+void beacon_handler(void *arg);
 
 #ifdef __cplusplus
 }

--- a/modules/schedreg/Makefile
+++ b/modules/schedreg/Makefile
@@ -1,0 +1,3 @@
+MODULE = schedreg
+
+include $(RIOTBASE)/Makefile.base

--- a/modules/schedreg/schedreg.c
+++ b/modules/schedreg/schedreg.c
@@ -1,0 +1,123 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "utlist.h"
+
+#include "schedreg.h"
+#include "thread.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define SCHEDREG_QUEUE_SIZE  (4U)
+
+static msg_t _schedreg_msg_queue[SCHEDREG_QUEUE_SIZE];
+static char schedreg_stack[THREAD_STACKSIZE_DEFAULT];
+
+/**
+ * @brief   Keep the head of the registers thread as global variable
+ */
+schedreg_t *schedreg = NULL;
+
+static schedreg_t *_schedreg_find_nth(int pos)
+{
+    schedreg_t *tmp = schedreg;
+
+    for (int i = 0; (i < pos) && tmp; i++) {
+        tmp = tmp->next;
+    }
+    return tmp;
+}
+
+static int _schedreg_num(void)
+{
+    int num = 0;
+    schedreg_t *tmp = schedreg;
+    while(tmp != NULL) {
+        tmp = tmp->next;
+        num++;
+    }
+    return num;
+}
+
+static void _schedreg_update(void)
+{
+    schedreg_t *tmp = schedreg;
+    int count = _schedreg_num();
+
+    for (int i = 0; (i < count); i++) {
+        tmp->msg->type = i + SCHEDREG_TYPE; 
+        tmp = tmp->next;
+    }
+}
+
+int schedreg_register(schedreg_t *entry, kernel_pid_t pid)
+{
+    int count = _schedreg_num();
+    if( count >= 0xFF) {
+        DEBUG("[DEBUG] schedreg: registry full \n");        
+        return 1;
+    }
+    entry->msg->type = SCHEDREG_TYPE + count;
+    LL_APPEND(schedreg, entry);
+    schedreg_resched(count, pid);
+    return 0;
+}
+
+void schedreg_unregister(schedreg_t *entry)
+{
+    LL_DELETE(schedreg, entry);
+    _schedreg_update();
+}
+
+int schedreg_resched(int n, kernel_pid_t pid)
+{
+    schedreg_t *tmp = _schedreg_find_nth(n);
+    if(tmp) {
+        DEBUG("[DEBUG] schedreg: re-scheduling entry %d in %lu \n", n, tmp->period);        
+        xtimer_set_msg (tmp->xtimer, tmp->period, tmp->msg, pid);
+        tmp->cb(tmp->arg);
+        return 0;
+    }
+    else {
+        DEBUG("[DEBUG] schedreg:  entry %d not found\n", n);        
+        return 1;
+    }
+}
+
+static void *schedreg_thread(void *args)
+{
+    (void) args;
+    msg_init_queue(_schedreg_msg_queue, SCHEDREG_QUEUE_SIZE);
+    msg_t msg;
+
+    while(msg_receive(&msg))
+    {
+        DEBUG("[DEBUG] schedreg: msg received \n");
+        if(msg.type >= SCHEDREG_TYPE ) {
+            schedreg_resched(msg.type - SCHEDREG_TYPE, thread_getpid());
+        }
+        else {
+            DEBUG("[DEBUG] schedreg: unknown msg typereceived\n");        
+        }
+    }
+
+    return NULL;
+}
+
+int init_schedreg_thread(void)
+{
+    int schedreg_pid = thread_create(schedreg_stack, sizeof(schedreg_stack),
+                                   THREAD_PRIORITY_MAIN - 1,
+                                   THREAD_CREATE_STACKTEST, schedreg_thread,
+                                   NULL, "Schedreg thread");
+    if (schedreg_pid == -EINVAL || schedreg_pid == -EOVERFLOW) {
+        puts("Error: failed to create schedreg thread, exiting\n");
+        return schedreg_pid;
+    }
+    else {
+        puts("Successfuly created schedreg thread !\n");
+        return schedreg_pid;
+    }
+}

--- a/modules/schedreg/schedreg.h
+++ b/modules/schedreg/schedreg.h
@@ -1,0 +1,127 @@
+
+#ifndef SCHEDREG_H
+#define SCHEDREG_H
+
+#include <inttypes.h>
+
+#include "msg.h"
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Message offset for schedreg msg.type
+ */
+#define SCHEDREG_TYPE           (0xC00)          
+
+/**
+ * @brief Signature for the sched callback
+ *
+ * @param[in] arg           optional argument which is passed to the
+ *                          callback
+ */
+typedef void (*sched_cb_t)(void *arg);
+
+/**
+ * @brief   Schedule entry
+ */
+typedef struct schedreg {
+    struct schedreg* next;         /**< pointer to next entry */
+    sched_cb_t cb;                 /**< cb to execute upon message*/
+    void* arg;                     /**< cb args */
+    msg_t* msg;                    /**< msg to send */
+    xtimer_t* xtimer;              /**< xtimer to schedule msg send */
+    uint32_t period;               /**< message period */
+} schedreg_t;
+
+/**
+ * @brief   Registers a thread to the registry.
+ *
+ * @param[in] entry     An entry you want to add to the registry.
+ * @param[in] pid    the PID of that will handle scheduling
+ *
+ * @warning Call schedreg_unregister() *before* you leave the context you
+ *          allocated @p entry in. Otherwise it might get overwritten.
+ *
+ * @return  0 on success
+ * @return  -EINVAL if invalid entry
+ */
+int schedreg_register(schedreg_t *entry, kernel_pid_t pid);
+
+/**
+ * @brief   Removes an entry from registry
+ *
+ * @param[in] entry     An entry you want to remove from the registry.
+ */
+void schedreg_unregister(schedreg_t *entry);
+
+
+/**
+ * @name    Static entry initialization macros
+ * @anchor  schedreg_init_static
+ * @{
+ */
+/**
+ * @brief   Initializes a schedreg entry
+ *
+ * @param[in] type      The @ref schedreg_type_t for the schedreg entry
+ * @param[in] pid       The PID of the registering thread
+ *
+ * @return  An initialized schedreg entry
+ */
+#define SCHEDREG_INIT(cb, arg, msg, xtimer, period)  { NULL, cb, arg, msg, xtimer, period}
+
+/**
+ * @name    Dynamic entry initialization functions
+ * @anchor  schedreg_init_dyn
+ * @{
+ */
+/**
+ * @brief   Initializes a schedreg entry dynamically with PID
+ *
+ * @param[out] entry    A schedreg entry
+ * @param[in] cb        The cb to be executed
+ * @param[in] arg       The args for the callback
+ * @param[in] msg       Pointer to msg_t to send to self
+ * @param[in] xtimer    Pointer to xtimer that will handle sheduling msg send
+ * @param[in] period    The time period in us for the cb execution
+ * 
+ */
+static inline void schedreg_init_pid(schedreg_t *entry,
+                                         sched_cb_t cb,
+                                         void* arg,
+                                         msg_t* msg,
+                                         xtimer_t* xtimer,
+                                         uint32_t period)
+{
+    entry->next = NULL;
+    entry->cb = cb;
+    entry->arg = arg;
+    entry->msg = msg;
+    entry->xtimer = xtimer;
+    entry->period = period;
+}
+
+/**
+ * @brief   Executes the n element callback and re-schedule
+ *
+ * @param[in] n      nth element in linked list
+ * @param[in] pid    the PID of that will handle scheduling
+ *
+ */
+int schedreg_resched(int n, kernel_pid_t pid);
+
+/**
+ * @brief   Inits schedreg as main thread
+ * 
+ * @param[out] pid    pid of thread
+ */
+int init_schedreg_thread(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds a a schedreg module. This module allows registering functions to be called on its main thread at a specific interval. The advantages of this si that just as the `apps/node_combo` example show you reduce the amount of threads needed to only 1 independently of the different resources to publish (beacon, bmx280 and css811).

So far I only adapted `node_bmx280` and `node_ccs811`, the other applications ares still supported in the same way. 